### PR TITLE
changed 8.0.30-23-1.focal to 8.0.30-22-1.focal on ci workflow tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,15 +84,15 @@ jobs:
       matrix:
         include:
           - mysql-version: "8.0.30"
-            percona-version: "8.0.30-23-1.focal"
+            percona-version: "8.0.30-22-1.focal"
             python-version: "3.9"
             ubuntu-version: "20.04"
           - mysql-version: "8.0.30"
-            percona-version: "8.0.30-23-1.focal"
+            percona-version: "8.0.30-22-1.focal"
             python-version: "3.10"
             ubuntu-version: "20.04"
           - mysql-version: "8.0.30"
-            percona-version: "8.0.30-23-1.focal"
+            percona-version: "8.0.30-22-1.focal"
             python-version: "3.11"
             ubuntu-version: "20.04"
           - mysql-version: "8.0.32"


### PR DESCRIPTION
# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)
