### PR TITLE
remove checks for percona 8.0.30-23-1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,18 +83,6 @@ jobs:
       # skipping matrix items that aren't meaningful
       matrix:
         include:
-          - mysql-version: "8.0.30"
-            percona-version: "8.0.30-23-1.focal"
-            python-version: "3.9"
-            ubuntu-version: "20.04"
-          - mysql-version: "8.0.30"
-            percona-version: "8.0.30-23-1.focal"
-            python-version: "3.10"
-            ubuntu-version: "20.04"
-          - mysql-version: "8.0.30"
-            percona-version: "8.0.30-23-1.focal"
-            python-version: "3.11"
-            ubuntu-version: "20.04"
           - mysql-version: "8.0.32"
             percona-version: "8.0.32-26-1.focal"
             python-version: "3.9"


### PR DESCRIPTION
CI is breaking, seems percona removed 8.0.30.23.1.focal from the repo.