### PR TITLE
track block mismatch errors when taking a basebackup

### DIFF
--- a/myhoard/errors.py
+++ b/myhoard/errors.py
@@ -9,6 +9,10 @@ class XtraBackupError(Exception):
     """Raised when the backup operation fails."""
 
 
+class BlockMismatchError(XtraBackupError):
+    """Raised when XtraBackup fails due to log block mismatch"""
+
+
 class UnknownBackupSite(Exception):
     """Referenced backup site not in configuration."""
 


### PR DESCRIPTION
# About this change: What it does, why it matters

Sometimes xtrabackup might fail when keeping up with redo logs, this will end up with an error due to block mismatches. Will be nice to track such errors, this way maybe we know when to set `redo_log_archiving=true` and retry taking the backup again... as just restarting myhoard is not the proper solution.


Seems there is a misconception that xtrabackup is not releasing correctly the backup lock, when the case is that the BackupStream keeps retrying on taking a basebackup, xtrabackup takes the lock and eventually fails due to block mismatch. This might take a long time, so myhoard will keep complaining when purging binlogs.
