### PR TITLE
Use rohmu transfer pool to fix io error on closed fds on restore

### DIFF
--- a/myhoard.spec
+++ b/myhoard.spec
@@ -26,7 +26,7 @@ Requires:       percona-xtrabackup-80 >= 8.0
 Requires:       python3-aiohttp
 Requires:       python3-cryptography >= 0.8
 Requires:       python3-PyMySQL >= 0.9.2
-Requires:       python3-rohmu >= 1.0.7
+Requires:       python3-rohmu >= 1.1.2
 Requires:       systemd
 
 %undefine _missing_build_ids_terminate_build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "PySocks",
     # rohmu is incompatible with latest version snappy 0.7.1
     "python-snappy == 0.6.1",
-    "rohmu == 1.0.7",
+    "rohmu >= 1.1.2",
     "sentry-sdk==1.14.0",
 ]
 


### PR DESCRIPTION
# About this change: What it does, why it matters

Currently myhoard can fail with: `ValueError: I/O operation on closed file` during restore (. The problem is likely due to non thread-safety of the rohmu transfers.

Using rohmu's transfer pool we should eliminate any possible case in which multiple threads operated on the same transfer object, or cases in which a "stale" transfer object was used by a single thread.