### PR TITLE
Not marking backups as broken on version upgrade

### DIFF
--- a/myhoard/basebackup_restore_operation.py
+++ b/myhoard/basebackup_restore_operation.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from .errors import DiskFullError
-from .util import get_xtrabackup_version
+from .util import get_xtrabackup_version, parse_version, parse_xtrabackup_info
 from contextlib import suppress
 from rohmu.util import increase_pipe_capacity, set_stream_nonblocking
-from typing import Final, Optional
+from typing import Final, Optional, Tuple
 
 import base64
 import fnmatch
@@ -56,6 +56,7 @@ class BasebackupRestoreOperation:
         self.stream_handler = stream_handler
         self.temp_dir = None
         self.temp_dir_base = temp_dir
+        self.backup_xtrabackup_info = None
 
     def restore_backup(self):
         if os.path.exists(self.mysql_data_directory):
@@ -101,6 +102,16 @@ class BasebackupRestoreOperation:
                         self._process_xbstream_input_output()
 
                 self.data_directory_size_start = self._get_directory_size(self.temp_dir)
+                xtrabackup_info_path = os.path.join(self.temp_dir, "xtrabackup_info")
+                if os.path.exists(xtrabackup_info_path):
+                    with open(xtrabackup_info_path) as fh:
+                        xtrabackup_info_text = fh.read()
+                    self.backup_xtrabackup_info = parse_xtrabackup_info(xtrabackup_info_text)
+                    self.log.info(
+                        "Backup info. Tool version: %s, Server version: %s",
+                        self.backup_xtrabackup_info.get("tool_version"),
+                        self.backup_xtrabackup_info.get("server_version"),
+                    )
 
                 # TODO: Get some execution time numbers with non-trivial data sets for --prepare
                 # and --move-back commands and add progress monitoring if necessary (and feasible)
@@ -159,6 +170,12 @@ class BasebackupRestoreOperation:
                 shutil.rmtree(self.temp_dir)
 
         self.data_directory_size_end = self._get_directory_size(self.mysql_data_directory, cleanup=True)
+
+    @property
+    def backup_xtrabackup_version(self) -> Optional[Tuple[int, ...]]:
+        if self.backup_xtrabackup_info is None or "tool_version" not in self.backup_xtrabackup_info:
+            return None
+        return parse_version(self.backup_xtrabackup_info["tool_version"])
 
     def _get_directory_size(self, directory_name, cleanup=False):
         # auto.cnf shouldn't be present to begin with but make extra sure so that we get new server UUID

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1224,7 +1224,8 @@ class Controller(threading.Thread):
         self._process_local_binlog_updates()
         self._extend_binlog_stream_list()
         if self.restore_coordinator.phase is RestoreCoordinator.Phase.failed_basebackup:
-            self._mark_failed_restore_backup_as_broken()
+            if self.restore_coordinator.should_mark_backup_as_broken():
+                self._mark_failed_restore_backup_as_broken()
             self._switch_basebackup_if_possible()
         if self.state["promote_on_restore_completion"] and self.restore_coordinator.is_complete():
             self.state_manager.update_state(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -98,9 +98,10 @@ def mysql_initialize_and_start(
     if mysql_basedir is None and os.path.exists("/opt/mysql"):
         mysql_basedir = "/opt/mysql"
 
-    mysqld_bin = os.environ.get("MYSQL_BINARY_PATH") or "/usr/sbin/mysqld"
-    if not os.path.exists(mysqld_bin):
-        mysqld_bin = "/usr/bin/mysqld"
+    mysqld_bin = shutil.which("mysqld")
+    assert mysqld_bin, f"mysqld binary not found in PATH: {os.environ['PATH']}"
+    xtrabackup_bin = shutil.which("xtrabackup")
+    assert xtrabackup_bin, f"xtrabackup binary not found in PATH: {os.environ['PATH']}"
 
     test_base_dir = os.path.abspath(os.path.join(session_tmpdir().strpath, name))
     config_path = os.path.join(test_base_dir, "etc")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -383,6 +383,26 @@ def test_restart_unexpected_dead_sql_thread() -> None:
     assert mock_cursor.execute.call_args.args == ("START SLAVE SQL_THREAD",)
 
 
-def test_trabackup_version() -> None:
+def test_xtrabackup_version() -> None:
     version = myhoard_util.get_xtrabackup_version()
+    assert len(version) >= 3
     assert version < (99, 99, 99), "version is higher than expected"
+
+
+def test_parse_version() -> None:
+    version = myhoard_util.parse_version("8.0.35-3")
+    assert version == (8, 0, 35, 3)
+
+
+def test_parse_xtrabackup_info() -> None:
+    raw_xtrabackup_info = """
+    name =
+    tool_version = 8.0.30-23
+    server_version = 8.0.30
+    """
+    xtrabackup_info = myhoard_util.parse_xtrabackup_info(raw_xtrabackup_info)
+    assert xtrabackup_info == {
+        "name": "",
+        "tool_version": "8.0.30-23",
+        "server_version": "8.0.30",
+    }


### PR DESCRIPTION
If a backup fails to restore, but the Percona PXB version used to create the backup differs from the current version, we do not mark the backup as "broken". The issue may be related to Percona PXB version compatibility.