### PR TITLE
Add support for incremental backups [BF-3005]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt update && \
         liblz4-1 liblz4-dev libldap2-dev libsasl2-dev libsasl2-modules-gssapi-mit libkrb5-dev wget \
         libreadline-dev libudev-dev libev-dev libev4 libprocps-dev vim-common
 # Download boost and percona-xtrabackup
-RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz && \
+RUN wget https://archives.boost.io/release/1.77.0/source/boost_1_77_0.tar.gz && \
     tar -zxvf boost_1_77_0.tar.gz
 
 
@@ -83,9 +83,9 @@ COPY --from=builder-percona-server /usr/local/mysql/bin /usr/bin
 COPY --from=builder-percona-server /usr/local/mysql/lib /usr/lib
 
 ADD requirement* /src/
-RUN scripts/install-python-deps
 RUN sudo scripts/create-user
 
 ADD . /src/
+RUN scripts/install-python-deps
 RUN git config --global --add safe.directory /src
 RUN python -m pip install -e .

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ backup daemon for PostgreSQL.
   standby servers)
 - Almost no extra local disk space requirements for creating and restoring
   backups
+- Incremental backups
 
 Fault-resilience and monitoring:
 
@@ -214,6 +215,18 @@ Name of the backup site to which new backups should be created to. See
 `backup_sites` for more information. Only needs to be defined if multiple
 non-recovery backup sites are present.
 
+**incremental.enabled**
+
+Boolean setting, which controls periodic incremental backups, according to the schedule
+`incremental.full_backup_week_schedule`
+
+**incremental.full_backup_week_schedule**
+
+A string of comma-separated days of the week: `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`.
+Defines on which days full backups should be taken, thus other days incremental backups will be done.
+E.g. if the value of this setting is `sun,wed`, then full backup is taken on Sundays and Wednesdays, other days of the
+week incremental backups will be scheduled. Requires `"incremental.enabled": true`.
+
 **backup_sites**
 
 Object storage configurations and encryption keys. This is an object with
@@ -343,6 +356,11 @@ here.
 The full path and file name prefix of relay logs. This must be the same as the
 corresponding MySQL configuration option except full path is always required
 here.
+
+**restore_auto_mark_backups_broken**
+
+Boolean value. Enables a mechanism to automatically mark backups as broken if restoration fails for
+multiple times in a row. Defaults to `false`
 
 **restore_free_memory_percentage**
 
@@ -526,7 +544,8 @@ binary log file. Request body must be like this:
 ```
 {
   "backup_type": "{basebackup|binlog}",
-  "wait_for_upload": 3.0
+  "wait_for_upload": 3.0,
+  "incremental": false
 }
 ```
 
@@ -543,6 +562,12 @@ backed up.
 This is only valid in case `backup_type` is `binlog`. In that case the
 operation will block for up to as many seconds as specified by this parameter
 for the binary log upload to complete before returning.
+
+**incremental**
+
+Boolean value, when `true` - requests incremental base backup if possible.
+Setting is used only in combination with `basebackup` backup_type.
+Defaults to `false`.
 
 Response on success looks like this:
 

--- a/myhoard.json
+++ b/myhoard.json
@@ -7,7 +7,11 @@
         "backup_interval_minutes": 1440,
         "backup_minute": 0,
         "forced_binlog_rotation_interval": 300,
-        "upload_site": "default"
+        "upload_site": "default",
+        "incremental": {
+            "enabled": false,
+            "full_backup_week_schedule": "sun,wed"
+        }
     },
     "backup_sites": {
         "default": {
@@ -47,6 +51,7 @@
         "relay_log_index_file": "/var/lib/mysql/relay.index",
         "relay_log_prefix": "/var/lib/mysql/relay"
     },
+    "restore_auto_mark_backups_broken": false,
     "restore_free_memory_percentage": null,
     "restore_max_binlog_bytes": 4294967296,
     "sentry_dsn": null,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -103,6 +103,7 @@ def build_controller(
         stats=build_statsd_client(),
         temp_dir=temp_dir,
         xtrabackup_settings=myhoard_util.DEFAULT_XTRABACKUP_SETTINGS,
+        auto_mark_backups_broken=True,
     )
     return controller
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -334,6 +334,7 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
             "backup_minute": 0,
             "forced_binlog_rotation_interval": 300,
             "upload_site": "default",
+            "incremental": {"enabled": False, "full_backup_week_schedule": "sun,wed"},
         },
         "backup_sites": {
             "default": default_backup_site,
@@ -360,6 +361,7 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
             "relay_log_index_file": mysql_master.config_options.relay_log_index_file,
             "relay_log_prefix": mysql_master.config_options.relay_log_file_prefix,
         },
+        "restore_auto_mark_backups_broken": True,
         "restore_free_memory_percentage": 50,
         "restore_max_binlog_bytes": 4294967296,
         "sentry_dsn": None,

--- a/test/helpers/version.py
+++ b/test/helpers/version.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+from myhoard.util import BinVersion
+
+
+def xtrabackup_version_to_string(version: BinVersion) -> str:
+    v = list(version)
+    assert 3 <= len(v) <= 4, f"Unexpected format of tool version: {v}"
+    version_str = ".".join(str(v) for v in v[:3])
+    if len(v) > 3:
+        version_str += f"-{v[3]}"
+    print(version_str)
+    return version_str

--- a/test/test_basebackup_restore_operation.py
+++ b/test/test_basebackup_restore_operation.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from . import build_statsd_client, wait_for_port
+from .helpers.version import xtrabackup_version_to_string
 from myhoard.basebackup_operation import BasebackupOperation
 from myhoard.basebackup_restore_operation import BasebackupRestoreOperation
 from unittest.mock import patch
@@ -15,15 +16,29 @@ pytestmark = [pytest.mark.unittest, pytest.mark.all]
 
 
 def test_get_xtrabackup_cmd():
-    cmd = BasebackupRestoreOperation.get_xtrabackup_cmd(None)
+    op_kwargs = {
+        "encryption_algorithm": "AES256",
+        "encryption_key": "123",
+        "free_memory_percentage": 80,
+        "mysql_config_file_name": "/etc/mysql/mysql.conf",
+        "mysql_data_directory": "/usr/lib/mysql/",
+        "stats": build_statsd_client(),
+        "stream_handler": None,
+        "target_dir": "",
+        "temp_dir": "",
+    }
+    op = BasebackupRestoreOperation(**op_kwargs)
+    cmd = op.get_xtrabackup_cmd()
     assert cmd == "xtrabackup"
     xtrabackup_path = shutil.which("xtrabackup")
     xtrabackup_dir = os.path.dirname(xtrabackup_path)
     xtrabackup_version = myhoard_util.get_xtrabackup_version()
     with patch.dict(os.environ, {"PXB_EXTRA_BIN_PATHS": xtrabackup_dir}):
-        cmd = BasebackupRestoreOperation.get_xtrabackup_cmd(xtrabackup_version)
+        cmd = BasebackupRestoreOperation(
+            **op_kwargs, backup_tool_version=xtrabackup_version_to_string(xtrabackup_version)
+        ).get_xtrabackup_cmd()
         assert cmd == xtrabackup_path
-        cmd = BasebackupRestoreOperation.get_xtrabackup_cmd((8, 0, 0))
+        cmd = BasebackupRestoreOperation(**op_kwargs, backup_tool_version="8.0.0").get_xtrabackup_cmd()
         assert cmd == "xtrabackup"
 
 
@@ -63,27 +78,21 @@ def test_basic_restore(mysql_master, mysql_empty):
             shutil.copyfileobj(backup_file, stream)
             stream.close()
 
-        get_xtrabackup_cmd_called_with = []
-        original_get_xtrabackup_cmd = BasebackupRestoreOperation.get_xtrabackup_cmd
-
-        def patched_get_xtrabackup_cmd(backup_xtrabackup_version):
-            get_xtrabackup_cmd_called_with.append(backup_xtrabackup_version)
-            return original_get_xtrabackup_cmd(backup_xtrabackup_version)
-
-        restore_op = BasebackupRestoreOperation(
-            encryption_algorithm="AES256",
-            encryption_key=encryption_key,
-            free_memory_percentage=80,
-            mysql_config_file_name=mysql_empty.config_name,
-            mysql_data_directory=mysql_empty.config_options.datadir,
-            stats=build_statsd_client(),
-            stream_handler=input_stream_handler,
-            temp_dir=mysql_empty.base_dir,
-        )
-        with patch.object(restore_op, "get_xtrabackup_cmd", side_effect=patched_get_xtrabackup_cmd):
+        with tempfile.TemporaryDirectory(dir=mysql_empty.base_dir, prefix="myhoard_target_") as temp_target_dir:
+            restore_op = BasebackupRestoreOperation(
+                encryption_algorithm="AES256",
+                encryption_key=encryption_key,
+                free_memory_percentage=80,
+                mysql_config_file_name=mysql_empty.config_name,
+                mysql_data_directory=mysql_empty.config_options.datadir,
+                stats=build_statsd_client(),
+                stream_handler=input_stream_handler,
+                target_dir=temp_target_dir,
+                temp_dir=mysql_empty.base_dir,
+                backup_tool_version=xtrabackup_version_to_string(myhoard_util.get_xtrabackup_version()),
+            )
+            restore_op.prepare_backup()
             restore_op.restore_backup()
-        # Check that correct PXB version was extracted from the backup
-        assert get_xtrabackup_cmd_called_with == [myhoard_util.get_xtrabackup_version()]
 
         assert restore_op.number_of_files >= backup_op.number_of_files
 
@@ -101,4 +110,119 @@ def test_basic_restore(mysql_master, mysql_empty):
             assert sorted(result["id"] for result in results) == sorted(range(15))
         cursor.execute("SHOW MASTER STATUS")
         new_master_status = cursor.fetchone()
+        assert old_master_status["Executed_Gtid_Set"] == new_master_status["Executed_Gtid_Set"]
+
+
+def test_incremental_backup_restore(mysql_master, mysql_empty) -> None:
+    with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
+        for db_index in range(5):
+            cursor.execute(f"CREATE DATABASE test{db_index}")
+            cursor.execute(f"CREATE TABLE test{db_index}.foo{db_index} (id integer primary key)")
+            for value in range(10):
+                cursor.execute(f"INSERT INTO test{db_index}.foo{db_index} (id) VALUES ({value})")
+        cursor.execute("FLUSH LOGS")
+
+    encryption_key = os.urandom(24)
+
+    with tempfile.NamedTemporaryFile() as backup_file1, tempfile.NamedTemporaryFile() as backup_file2:
+
+        def build_stream_handler(backup_file):
+            def output_stream_handler(stream):
+                shutil.copyfileobj(stream, backup_file)
+
+            return output_stream_handler
+
+        backup_op = BasebackupOperation(
+            encryption_algorithm="AES256",
+            encryption_key=encryption_key,
+            mysql_client_params=mysql_master.connect_options,
+            mysql_config_file_name=mysql_master.config_name,
+            mysql_data_directory=mysql_master.config_options.datadir,
+            stats=build_statsd_client(),
+            stream_handler=build_stream_handler(backup_file1),
+            temp_dir=mysql_empty.base_dir,
+        )
+        backup_op.create_backup()
+
+        with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
+            for db_index in range(5, 10):
+                cursor.execute(f"CREATE DATABASE test{db_index}")
+                cursor.execute(f"CREATE TABLE test{db_index}.foo{db_index} (id integer primary key)")
+                for value in range(10):
+                    cursor.execute(f"INSERT INTO test{db_index}.foo{db_index} (id) VALUES ({value})")
+            cursor.execute("FLUSH LOGS")
+            cursor.execute("SHOW MASTER STATUS")
+            old_master_status = cursor.fetchone()
+            assert old_master_status
+
+        backup_op_inc = BasebackupOperation(
+            encryption_algorithm="AES256",
+            encryption_key=encryption_key,
+            mysql_client_params=mysql_master.connect_options,
+            mysql_config_file_name=mysql_master.config_name,
+            mysql_data_directory=mysql_master.config_options.datadir,
+            stats=build_statsd_client(),
+            stream_handler=build_stream_handler(backup_file2),
+            temp_dir=mysql_empty.base_dir,
+            incremental_since_checkpoint=backup_op.checkpoints_file_content,
+        )
+        backup_op_inc.create_backup()
+
+        def build_input_stream_handler(backup_file):
+            backup_file.seek(0)
+
+            def input_stream_handler(stream):
+                shutil.copyfileobj(backup_file, stream)
+                stream.close()
+
+            return input_stream_handler
+
+        with tempfile.TemporaryDirectory(dir=mysql_empty.base_dir, prefix="myhoard_target_") as temp_target_dir:
+            restore_op = BasebackupRestoreOperation(
+                encryption_algorithm="AES256",
+                encryption_key=encryption_key,
+                free_memory_percentage=80,
+                mysql_config_file_name=mysql_empty.config_name,
+                mysql_data_directory=mysql_empty.config_options.datadir,
+                stats=build_statsd_client(),
+                stream_handler=build_input_stream_handler(backup_file1),
+                target_dir=temp_target_dir,
+                temp_dir=mysql_empty.base_dir,
+            )
+            restore_op.prepare_backup(
+                incremental=False, apply_log_only=True, checkpoints_file_content=backup_op.checkpoints_file_content
+            )
+            restore_op_inc = BasebackupRestoreOperation(
+                encryption_algorithm="AES256",
+                encryption_key=encryption_key,
+                free_memory_percentage=80,
+                mysql_config_file_name=mysql_empty.config_name,
+                mysql_data_directory=mysql_empty.config_options.datadir,
+                stats=build_statsd_client(),
+                stream_handler=build_input_stream_handler(backup_file2),
+                target_dir=temp_target_dir,
+                temp_dir=mysql_empty.base_dir,
+            )
+            restore_op_inc.prepare_backup(
+                incremental=True, apply_log_only=False, checkpoints_file_content=backup_op_inc.checkpoints_file_content
+            )
+            restore_op_inc.restore_backup()
+
+        assert restore_op_inc.number_of_files >= backup_op.number_of_files
+
+    mysql_empty.proc = subprocess.Popen(mysql_empty.startup_command)  # pylint: disable=consider-using-with
+    wait_for_port(mysql_empty.port)
+
+    with myhoard_util.mysql_cursor(
+        password=mysql_master.password,
+        port=mysql_empty.port,
+        user=mysql_master.user,
+    ) as cursor:
+        for db_index in range(10):
+            cursor.execute(f"SELECT id FROM test{db_index}.foo{db_index}")
+            results = cursor.fetchall()
+            assert sorted(result["id"] for result in results) == sorted(range(10))
+        cursor.execute("SHOW MASTER STATUS")
+        new_master_status = cursor.fetchone()
+        assert new_master_status
         assert old_master_status["Executed_Gtid_Set"] == new_master_status["Executed_Gtid_Set"]

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -465,6 +465,7 @@ def test_should_mark_backup_as_broken(session_tmpdir):
         stream_id="-",
         target_time=None,
         temp_dir="/dev/null",
+        auto_mark_backups_broken=True,
     )
     assert not rc.should_mark_backup_as_broken()
     rc.update_state(phase=rc.Phase.failed_basebackup, backup_xtrabackup_version=None)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -400,6 +400,7 @@ def test_parse_xtrabackup_info() -> None:
     name =
     tool_version = 8.0.30-23
     server_version = 8.0.30
+    unparsable line
     """
     xtrabackup_info = myhoard_util.parse_xtrabackup_info(raw_xtrabackup_info)
     assert xtrabackup_info == {
@@ -420,3 +421,20 @@ def test_find_extra_xtrabackup_executables() -> None:
         assert len(bin_infos) == 1
         assert bin_infos[0].path.name == "xtrabackup"
         assert bin_infos[0].version >= (8, 0, 30)
+
+
+@pytest.mark.parametrize(
+    "dow_schedule,result",
+    [
+        ("abracadabra", ValueError),
+        ("", ValueError),
+        ("mon,wed", {0, 2}),
+        ("sun", {6}),
+    ],
+)
+def test_parse_dow_schedule(dow_schedule: str, result: set[int] | type) -> None:
+    if not isinstance(result, set):
+        with pytest.raises(result):
+            myhoard_util.parse_dow_schedule(dow_schedule)
+    else:
+        assert myhoard_util.parse_dow_schedule(dow_schedule) == result


### PR DESCRIPTION
# About this change: What it does, why it matters
* Add support for incremental backup (via backup endpoint and/or schedule). This helps reduce costs of object storage and potentially speed up the backup (however the restoration will take longer as more than one backup needs to be restored).

* Disable mark as broken automatic functionality

* Add incremental tag to backup/restoration metrics