### PR TITLE
Allow using "--use-free-memory" only for PBX 8.0.32 or higher

### DIFF
--- a/myhoard/basebackup_restore_operation.py
+++ b/myhoard/basebackup_restore_operation.py
@@ -124,7 +124,8 @@ class BasebackupRestoreOperation:
                     "--target-dir",
                     self.temp_dir,
                 ]
-                if self.free_memory_percentage is not None and get_xtrabackup_version() >= (8, 0, 30):
+                # --use-free-memory-pct introduced in 8.0.30, but it doesn't work in 8.0.30 and leads to PBX crash
+                if self.free_memory_percentage is not None and get_xtrabackup_version() >= (8, 0, 32):
                     command_line.insert(2, f"--use-free-memory-pct={self.free_memory_percentage}")
                 with self.stats.timing_manager("myhoard.basebackup_restore.xtrabackup_prepare"):
                     with subprocess.Popen(


### PR DESCRIPTION
Adding this parameter leads to PBX crash for version 8.0.30.
