### PR TITLE
Use the same PXB version for restoring the backup as was used for its creation

### DIFF
--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -2,7 +2,12 @@
 from myhoard import version
 from myhoard.controller import Controller
 from myhoard.statsd import StatsClient
-from myhoard.util import DEFAULT_XTRABACKUP_SETTINGS, detect_running_process_id, wait_for_port
+from myhoard.util import (
+    DEFAULT_XTRABACKUP_SETTINGS,
+    detect_running_process_id,
+    find_extra_xtrabackup_executables,
+    wait_for_port,
+)
 from myhoard.web_server import WebServer
 
 import argparse
@@ -100,6 +105,10 @@ class MyHoard:
 
         if self.config["http_address"] not in {"127.0.0.1", "::1", "localhost"}:
             self.log.warning("Binding to non-localhost address %r is highly discouraged", self.config["http_address"])
+
+        extra_pxb_bins = find_extra_xtrabackup_executables()
+        if extra_pxb_bins:
+            self.log.info("Found extra xtrabackup binaries: %r", extra_pxb_bins)
 
         self.log.info("Configuration loaded")
 

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -9,6 +9,7 @@ from .statsd import StatsClient
 from .table import Table
 from .util import (
     add_gtid_ranges_to_executed_set,
+    BinVersion,
     build_gtid_ranges,
     change_master_to,
     DEFAULT_MYSQL_TIMEOUT,
@@ -150,7 +151,7 @@ class RestoreCoordinator(threading.Thread):
         server_uuid: Optional[str]
         target_time_reached: bool
         write_relay_log_manually: bool
-        backup_xtrabackup_version: Tuple[int, ...] | None
+        backup_xtrabackup_version: BinVersion | None
 
     POLL_PHASES = {Phase.waiting_for_apply_to_finish}
 

--- a/test/test_basebackup_restore_operation.py
+++ b/test/test_basebackup_restore_operation.py
@@ -2,6 +2,7 @@
 from . import build_statsd_client, wait_for_port
 from myhoard.basebackup_operation import BasebackupOperation
 from myhoard.basebackup_restore_operation import BasebackupRestoreOperation
+from unittest.mock import patch
 
 import myhoard.util as myhoard_util
 import os
@@ -11,6 +12,19 @@ import subprocess
 import tempfile
 
 pytestmark = [pytest.mark.unittest, pytest.mark.all]
+
+
+def test_get_xtrabackup_cmd():
+    cmd = BasebackupRestoreOperation.get_xtrabackup_cmd(None)
+    assert cmd == "xtrabackup"
+    xtrabackup_path = shutil.which("xtrabackup")
+    xtrabackup_dir = os.path.dirname(xtrabackup_path)
+    xtrabackup_version = myhoard_util.get_xtrabackup_version()
+    with patch.dict(os.environ, {"PXB_EXTRA_BIN_PATHS": xtrabackup_dir}):
+        cmd = BasebackupRestoreOperation.get_xtrabackup_cmd(xtrabackup_version)
+        assert cmd == xtrabackup_path
+        cmd = BasebackupRestoreOperation.get_xtrabackup_cmd((8, 0, 0))
+        assert cmd == "xtrabackup"
 
 
 def test_basic_restore(mysql_master, mysql_empty):
@@ -49,6 +63,13 @@ def test_basic_restore(mysql_master, mysql_empty):
             shutil.copyfileobj(backup_file, stream)
             stream.close()
 
+        get_xtrabackup_cmd_called_with = []
+        original_get_xtrabackup_cmd = BasebackupRestoreOperation.get_xtrabackup_cmd
+
+        def patched_get_xtrabackup_cmd(backup_xtrabackup_version):
+            get_xtrabackup_cmd_called_with.append(backup_xtrabackup_version)
+            return original_get_xtrabackup_cmd(backup_xtrabackup_version)
+
         restore_op = BasebackupRestoreOperation(
             encryption_algorithm="AES256",
             encryption_key=encryption_key,
@@ -59,7 +80,10 @@ def test_basic_restore(mysql_master, mysql_empty):
             stream_handler=input_stream_handler,
             temp_dir=mysql_empty.base_dir,
         )
-        restore_op.restore_backup()
+        with patch.object(restore_op, "get_xtrabackup_cmd", side_effect=patched_get_xtrabackup_cmd):
+            restore_op.restore_backup()
+        # Check that correct PXB version was extracted from the backup
+        assert get_xtrabackup_cmd_called_with == [myhoard_util.get_xtrabackup_version()]
 
         assert restore_op.number_of_files >= backup_op.number_of_files
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -12,6 +12,7 @@ import os
 import pymysql
 import pytest
 import random
+import shutil
 import subprocess
 
 pytestmark = [pytest.mark.unittest, pytest.mark.all]
@@ -406,3 +407,16 @@ def test_parse_xtrabackup_info() -> None:
         "tool_version": "8.0.30-23",
         "server_version": "8.0.30",
     }
+
+
+def test_find_extra_xtrabackup_executables() -> None:
+    bin_infos = myhoard_util.find_extra_xtrabackup_executables()
+    assert len(bin_infos) == 0
+    xtrabackup_path = shutil.which("xtrabackup")
+    assert xtrabackup_path is not None
+    xtrabackup_dir = os.path.dirname(xtrabackup_path)
+    with patch.dict(os.environ, {"PXB_EXTRA_BIN_PATHS": xtrabackup_dir}):
+        bin_infos = myhoard_util.find_extra_xtrabackup_executables()
+        assert len(bin_infos) == 1
+        assert bin_infos[0].path.name == "xtrabackup"
+        assert bin_infos[0].version >= (8, 0, 30)


### PR DESCRIPTION
Added a new environment variable `PXB_EXTRA_BIN_PATHS`, which allows specifying additional paths to PXB binaries. These binaries can be used for restoring backups with the corresponding version.