### PR TITLE
Expose "server_version" to GET /backup endpoint

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -1114,6 +1114,7 @@ class BackupStream(threading.Thread):
                 "start_size": self.basebackup_operation.data_directory_size_start,
                 "start_ts": start_time,
                 "tool_version": self.basebackup_operation.tool_version,
+                "server_version": self.basebackup_operation.server_version,
                 "uploaded_from": self.server_id,
             }
             self.file_storage.store_file_from_memory(

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -96,6 +96,7 @@ class BasebackupOperation:
         self.temp_dir: Optional[str] = None
         self.temp_dir_base = temp_dir
         self.tool_version: str | None = None
+        self.server_version: str | None = None
 
     def abort(self, reason):
         """Aborts ongoing backup generation"""
@@ -401,6 +402,7 @@ class BasebackupOperation:
             self.log.warning("binlog info wasn't found in `xtrabackup_info` file")
 
         self.tool_version = backup_xtrabackup_info.get("tool_version")
+        self.server_version = backup_xtrabackup_info.get("server_version")
 
     def _process_output_line_lsn_info(self, line):
         match = self.lsn_re.search(line)

--- a/test/test_basebackup_operation.py
+++ b/test/test_basebackup_operation.py
@@ -278,3 +278,5 @@ def test_process_binlog_info(mysql_master: MySQLConfig) -> None:
         "file_position": 238,
         "gtid": None,
     }
+    assert op.tool_version == "8.0.30-23.1.aiven"
+    assert op.server_version == "8.0.30"

--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -84,6 +84,33 @@ async def test_backup_list(master_controller, web_client):
             "stream_id",
         }
         assert set(backup) == expected
+        basebackup_info_expected = {
+            "binlog_index",
+            "binlog_name",
+            "binlog_position",
+            "backup_reason",
+            "checkpoints_file_content",
+            "compressed_size",
+            "encryption_key",
+            "end_size",
+            "end_ts",
+            "gtid",
+            "gtid_executed",
+            "incremental",
+            "required_streams",
+            "initiated_at",
+            "lsn_info",
+            "normalized_backup_time",
+            "number_of_files",
+            "split_size",
+            "number_of_splits",
+            "start_size",
+            "start_ts",
+            "tool_version",
+            "server_version",
+            "uploaded_from",
+        }
+        assert basebackup_info_expected == set(backup["basebackup_info"].keys())
 
     await awhile_asserts(has_backup)
 


### PR DESCRIPTION
Added `server_version` to `basebackup_info` 
```
    {
      "basebackup_info": {
        ...
        "tool_version": "8.0.35-32",
        "server_version": "8.0.35",
        ...
      },
```