### PR TITLE
Do not stop stream for broken backups

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -429,8 +429,6 @@ class BackupStream(threading.Thread):
             yield binlog
 
     def _mark_as_broken(self, key: str, file_storage: BaseTransfer):
-        self.stop()
-
         broken_info = {
             "broken_at": time.time(),
             "server_id": self.server_id,


### PR DESCRIPTION
Previously, marking an active stream as broken also closed it. This
stopped binlog uploads and left the system unable to take new
backups. Attempting to create a new backup would then enter a loop,
repeatedly logging "marked as closed multiple times".

With this change, the stream is no longer closed when marked as
broken, avoiding this failure loop and preventing data loss.