### PR TITLE
Added use_memory parameter to restore options

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,14 @@ Maximum percentage of system memory to allow xtrabackup to use while
 preparing a basebackup for restoration. If not defined, use xtrabackup's
 default value.
 
+**restore_use_memory**
+
+This option affects how much memory is allocated and is similar to
+innodb_buffer_pool_size. This option is only relevant in the --prepare phase.
+The default value is 100MB. The recommended value is between 1GB to 2GB.
+THe size is specified in bytes.
+When use_memory and free_memory_percentage are both set, free_memory_percentage will be ignored.
+
 **restore_max_binlog_bytes**
 
 Maximum amount of disk space to use for binary logs including pre-fetched logs

--- a/myhoard/basebackup_restore_operation.py
+++ b/myhoard/basebackup_restore_operation.py
@@ -52,6 +52,7 @@ class BasebackupRestoreOperation:
         target_dir: str,
         temp_dir: str,
         backup_tool_version: str | None = None,
+        use_memory: Optional[int] = None,
         prepare_progress_callback: Optional[Callable[..., None]] = None,
     ):
         self.current_file = None
@@ -70,6 +71,7 @@ class BasebackupRestoreOperation:
         self.stream_handler = stream_handler
         self.target_dir = target_dir
         self.temp_dir = temp_dir
+        self.use_memory = use_memory
         self.backup_xtrabackup_info: Dict[str, str] | None = None
         self.backup_tool_version = backup_tool_version
         # LSN bounds for prepare progress. Use last_lsn (redo stop LSN) over
@@ -168,8 +170,18 @@ class BasebackupRestoreOperation:
                         checkpoints_file.write(checkpoints_file_content)
 
                 # --use-free-memory-pct introduced in 8.0.30, but it doesn't work in 8.0.30 and leads to PBX crash
-                if self.free_memory_percentage is not None and get_xtrabackup_version() >= (8, 0, 32):
+                if (
+                    self.free_memory_percentage is not None
+                    and get_xtrabackup_version() >= (8, 0, 32)
+                    and self.use_memory is None
+                ):
                     command_line.insert(2, f"--use-free-memory-pct={self.free_memory_percentage}")
+                if self.use_memory is not None:
+                    if self.free_memory_percentage is not None:
+                        self.log.warning(
+                            "use_memory and free_memory_percentage are both set, free_memory_percentage will be ignored"
+                        )
+                    command_line.extend(["--use-memory", str(self.use_memory)])
                 self._set_prepare_current_lsn(None)
                 with self.stats.timing_manager("myhoard.basebackup_restore.xtrabackup_prepare"):
                     with subprocess.Popen(

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -184,6 +184,7 @@ class Controller(threading.Thread):
         temp_dir,
         restore_download_workers_count: int,
         restore_free_memory_percentage=None,
+        restore_use_memory: Optional[int] = None,
         xtrabackup_settings: Dict[str, int],
         auto_mark_backups_broken: bool = False,
     ):
@@ -228,6 +229,7 @@ class Controller(threading.Thread):
         self.restore_max_binlog_bytes = restore_max_binlog_bytes
         self.restore_download_workers_count = restore_download_workers_count
         self.restore_free_memory_percentage: Optional[int] = restore_free_memory_percentage
+        self.restore_use_memory = restore_use_memory
         self.restore_coordinator: Optional[RestoreCoordinator] = None
         self.seen_basebackup_infos: Dict[str, BaseBackup] = {}
         self.server_id = server_id
@@ -991,6 +993,7 @@ class Controller(threading.Thread):
             file_storage_config=storage_config,
             max_binlog_bytes=self.restore_max_binlog_bytes,
             free_memory_percentage=self.restore_free_memory_percentage,
+            use_memory=self.restore_use_memory,
             mysql_client_params=self.mysql_client_params,
             mysql_config_file_name=self.mysql_config_file_name,
             mysql_data_directory=self.mysql_data_directory,

--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -119,7 +119,8 @@ class MyHoard:
             raise Exception("Either 'start_command' or 'systemd_service' must be specified")
         if start_command and not isinstance(start_command, list):
             raise Exception("'start_command' must be a list")
-
+        if self.config.get("restore_use_memory") and self.config.get("restore_free_memory_percentage"):
+            self.log.warning("use_memory and free_memory_percentage are both set, free_memory_percentage will be ignored")
         backup_settings = self.config["backup_settings"]
         ival = backup_settings["backup_interval_minutes"]
         if (ival > 1440 and ival // 1440 * 1440 != ival) or (ival < 1440 and 1440 // ival * ival != 1440):
@@ -241,6 +242,7 @@ class MyHoard:
             restore_max_binlog_bytes=self.config["restore_max_binlog_bytes"],
             restore_download_workers_count=restore_download_workers_count,
             restore_free_memory_percentage=self.config.get("restore_free_memory_percentage"),
+            restore_use_memory=self.config.get("restore_use_memory"),
             server_id=self.config["server_id"],
             state_dir=self.config["state_directory"],
             stats=statsd,

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -192,6 +192,7 @@ class RestoreCoordinator(threading.Thread):
         download_workers_count: int,
         file_storage_config,
         free_memory_percentage,
+        use_memory: Optional[int] = None,
         max_binlog_bytes=None,
         mysql_client_params,
         mysql_config_file_name,
@@ -222,6 +223,7 @@ class RestoreCoordinator(threading.Thread):
         # can be successfully restored.
         self.binlog_streams = binlog_streams
         self.download_workers_count = download_workers_count
+        self.use_memory = use_memory
         self.current_file = None
         self.file_storage_pool = TransferPool()
         self.file_storage_config = file_storage_config
@@ -565,6 +567,7 @@ class RestoreCoordinator(threading.Thread):
             target_dir=target_dir,
             temp_dir=temp_dir,
             free_memory_percentage=self.free_memory_percentage,
+            use_memory=self.use_memory,
             backup_tool_version=backup_info.get("tool_version"),
             prepare_progress_callback=self._on_prepare_progress,
         )

--- a/test/test_basebackup_restore_operation.py
+++ b/test/test_basebackup_restore_operation.py
@@ -178,6 +178,35 @@ def test_get_xtrabackup_cmd():
         assert cmd == "xtrabackup"
 
 
+def test_prepare_command_applies_use_memory():
+    use_memory = 2 * 1024 * 1024 * 1024
+    op = BasebackupRestoreOperation(
+        encryption_algorithm="AES256",
+        encryption_key=b"0" * 24,
+        mysql_config_file_name="/etc/mysql/mysql.conf",
+        mysql_data_directory="/usr/lib/mysql/",
+        stats=build_statsd_client(),
+        free_memory_percentage=80,
+        stream_handler=None,
+        target_dir="",
+        temp_dir="",
+        use_memory=use_memory,
+    )
+    with (
+        patch("myhoard.basebackup_restore_operation.subprocess.Popen") as popen,
+        patch("myhoard.basebackup_restore_operation.get_xtrabackup_version", return_value=(8, 0, 33)),
+        patch.object(op, "_process_xbstream_input_output"),
+        patch.object(op, "_process_prepare_input_output"),
+    ):
+        op.prepare_backup()
+
+    assert popen.call_count == 2
+    prepare_command = popen.call_args_list[1][0][0]
+    assert "--prepare" in prepare_command
+    assert prepare_command[prepare_command.index("--use-memory") + 1] == str(use_memory)
+    assert not any(arg.startswith("--use-free-memory-pct") for arg in prepare_command)
+
+
 def test_basic_restore(mysql_master, mysql_empty):
     with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
         for db_index in range(15):

--- a/test/test_myhoard.py
+++ b/test/test_myhoard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from . import get_random_port, wait_for_port, while_asserts
 from myhoard.myhoard import MyHoard
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import contextlib
 import json
@@ -45,6 +45,23 @@ def test_sample_config_keys_match_fixture_config_keys(myhoard_config):
         actual_config = json.load(f)
 
     validate_recursive(actual_config, myhoard_config)
+
+
+def test_load_configuration_warns_when_use_memory_combined_with_free_memory_percentage(caplog):
+    config = {
+        "backup_settings": {"backup_interval_minutes": 1440},
+        "http_address": "127.0.0.1",
+        "start_command": ["mysqld"],
+        "restore_free_memory_percentage": 50,
+        "restore_use_memory": 2 * 1024 * 1024 * 1024,
+    }
+    hoard = MyHoard.__new__(MyHoard)
+    hoard.config_file = "myhoard.json"
+    hoard.log = logging.getLogger("MyHoard")
+    with patch("builtins.open", mock_open(read_data=json.dumps(config))):
+        with caplog.at_level(logging.WARNING, logger="MyHoard"):
+            hoard._load_configuration()  # pylint: disable=protected-access
+    assert "free_memory_percentage will be ignored" in caplog.text
 
 
 def test_basic_daemon_execution(myhoard_config):


### PR DESCRIPTION
Tested with sysbench with 8 tables and 20 milions rows


| use_memory        | Duration      |
|-------------|-------------------|
| 100 MB | **5m 09s** |
| 500 MB | **4m 10s** |
| 1 GB      |  **2m 15s** |
| 2 GB      | **3m 39s** |
| 4 GB      | **2m 25s** |