### PR TITLE
Add lock_ddl xtrabackup setting for reduced DDL locking [MYC-179]

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,23 @@ Number of worker threads created by XtraBackup for parallel compression when tak
 
 Number of worker threads created by XtraBackup for parallel encryption when taking a backup. The default value is ``1``.
 
+**xtrabackup.lock_ddl**
+
+How XtraBackup should lock DDL while taking a basebackup, either ``ON``
+(the default) or ``REDUCED``.
+
+With ``ON`` the DDL lock is taken before the data files are copied and held
+until the copy finishes, so the lock lasts as long as the backup and grows with
+the size of the data. With ``REDUCED`` the InnoDB data is copied without the
+lock, DDL is tracked through the redo log, and a short lock is taken at the end
+of the backup only to reconcile the tables that DDL touched. That keeps the lock
+window roughly constant regardless of how much data there is.
+
+``REDUCED`` requires Percona XtraBackup 8.4 or newer (and therefore MySQL 8.4 or
+newer). On older versions the setting is ignored and ``ON`` is used instead. It
+works for both full and incremental backups but cannot be combined with
+XtraBackup's page tracking, which MyHoard does not use.
+
 **xtrabackup.register_redo_log_consumer**
 
 Lets XtraBackup register as a redo log consumer at the start of the backup.

--- a/myhoard.json
+++ b/myhoard.json
@@ -78,6 +78,7 @@
         "compress_threads": 1,
         "encrypt_threads": 1,
         "estimate_memory": false,
+        "lock_ddl": "ON",
         "register_redo_log_consumer": false
     }
 }

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -186,7 +186,7 @@ class BackupStream(threading.Thread):
         stats: "StatsClient",
         stream_id: Optional[str] = None,
         temp_dir: str,
-        xtrabackup_settings: Optional[Dict[str, int]] = None,
+        xtrabackup_settings: Optional[Dict[str, Any]] = None,
         split_size: Optional[int] = 0,
         incremental_backup_info: IncrementalBackupInfo | None = None,
     ) -> None:
@@ -1046,6 +1046,7 @@ class BackupStream(threading.Thread):
             encryption_algorithm="AES256",
             encryption_key=encryption_key,
             estimate_memory=self.xtrabackup_settings["estimate_memory"],
+            lock_ddl=self.xtrabackup_settings["lock_ddl"],
             mysql_client_params=self.mysql_client_params,
             mysql_config_file_name=self.mysql_config_file_name,
             mysql_data_directory=self.mysql_data_directory,

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -1,7 +1,16 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from contextlib import suppress
 from myhoard.errors import BlockMismatchError, XtraBackupError
-from myhoard.util import CHECKPOINT_FILENAME, get_mysql_version, mysql_cursor, parse_xtrabackup_info
+from myhoard.util import (
+    BinVersion,
+    CHECKPOINT_FILENAME,
+    get_mysql_version,
+    get_xtrabackup_version,
+    LOCK_DDL_ON,
+    LOCK_DDL_REDUCED,
+    mysql_cursor,
+    parse_xtrabackup_info,
+)
 from packaging.version import Version
 from rohmu.util import increase_pipe_capacity, set_stream_nonblocking
 from typing import Any, Dict, List, Optional
@@ -19,6 +28,12 @@ import threading
 # Number of seconds to allow for database operations to complete
 # while running the OPTIMIZE TABLE mitigation
 CURSOR_TIMEOUT_DURING_OPTIMIZE: int = 120
+
+# --lock-ddl=REDUCED only exists in Percona XtraBackup 8.4 and newer (Pro since 8.4.0-2, community
+# since 8.4.0-5); the 8.0 series has no REDUCED enum value and refuses to start with it. Since the
+# backup always runs the xtrabackup that matches the server it backs up, checking the binary version
+# also covers the MySQL 8.4+ requirement of the feature.
+LOCK_DDL_REDUCED_MIN_XTRABACKUP_VERSION: BinVersion = (8, 4)
 
 
 class AbortRequested(Exception):
@@ -53,6 +68,7 @@ class BasebackupOperation:
         encryption_algorithm,
         encryption_key,
         estimate_memory=False,
+        lock_ddl: str = LOCK_DDL_ON,
         mysql_client_params,
         mysql_config_file_name,
         mysql_data_directory,
@@ -78,6 +94,7 @@ class BasebackupOperation:
         self.encryption_key = encryption_key
         self.estimate_memory = estimate_memory
         self.has_block_mismatch = False
+        self.lock_ddl = lock_ddl
         self.log = logging.getLogger(self.__class__.__name__)
         self.incremental_since_checkpoint = incremental_since_checkpoint
         self.prev_checkpoint_dir = None
@@ -182,7 +199,44 @@ class BasebackupOperation:
         if self.estimate_memory:
             command_line.append("--estimate-memory=ON")
 
+        if lock_ddl := self._resolve_lock_ddl():
+            command_line.append(f"--lock-ddl={lock_ddl}")
+
         return command_line
+
+    def _resolve_lock_ddl(self) -> str | None:
+        """Resolves the `--lock-ddl` value to put on the command line, or None to leave the option out.
+
+        Omitting the option is what MyHoard has always done and is equivalent to `--lock-ddl=ON`, which is
+        also xtrabackup's own default: the DDL lock is taken before the copy starts and held until it ends,
+        so its duration grows with the dataset. REDUCED instead copies InnoDB data unlocked, tracks DDL
+        through the redo log, and takes a short lock at the end only to reconcile the tables that DDL
+        touched, which keeps the lock window roughly flat as data grows.
+
+        REDUCED works for both full and incremental backups. It is incompatible with xtrabackup's page
+        tracking (`--page-tracking`), which MyHoard does not use - anything adding page tracking must not
+        combine it with REDUCED. See
+        https://docs.percona.com/percona-xtrabackup/8.4/reduction-in-locks.html
+        """
+        if self.lock_ddl == LOCK_DDL_ON:
+            return None
+
+        if self.lock_ddl != LOCK_DDL_REDUCED:
+            self.log.warning("Unsupported lock_ddl value %r, using %r instead", self.lock_ddl, LOCK_DDL_ON)
+            return None
+
+        xtrabackup_version = get_xtrabackup_version()
+        if xtrabackup_version < LOCK_DDL_REDUCED_MIN_XTRABACKUP_VERSION:
+            self.log.warning(
+                "lock_ddl %r requires Percona XtraBackup %r or newer but %r is in use, using %r instead",
+                LOCK_DDL_REDUCED,
+                LOCK_DDL_REDUCED_MIN_XTRABACKUP_VERSION,
+                xtrabackup_version,
+                LOCK_DDL_ON,
+            )
+            return None
+
+        return LOCK_DDL_REDUCED
 
     def is_incremental(self) -> bool:
         return self.incremental_since_checkpoint is not None

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -184,7 +184,7 @@ class Controller(threading.Thread):
         temp_dir,
         restore_download_workers_count: int,
         restore_free_memory_percentage=None,
-        xtrabackup_settings: Dict[str, int],
+        xtrabackup_settings: Dict[str, Any],
         auto_mark_backups_broken: bool = False,
     ):
         super().__init__()

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -34,11 +34,18 @@ ERR_TIMEOUT = 2013
 XTRABACKUP_VERSION_REGEX = re.compile(r"xtrabackup version ([\d\.\-]+)")
 VERSION_SPLITTING_REGEX = re.compile(r"[\.-]")
 
-DEFAULT_XTRABACKUP_SETTINGS = {
+# Values accepted by xtrabackup's --lock-ddl option. OFF is deliberately not supported here: it
+# leaves DDL executed during the copy phase entirely unprotected, which can produce a backup that
+# cannot be restored. Leaving the option out of the command line is equivalent to ON.
+LOCK_DDL_ON = "ON"
+LOCK_DDL_REDUCED = "REDUCED"
+
+DEFAULT_XTRABACKUP_SETTINGS: dict[str, Any] = {
     "copy_threads": 1,
     "compress_threads": 1,
     "encrypt_threads": 1,
     "estimate_memory": False,
+    "lock_ddl": LOCK_DDL_ON,
     "register_redo_log_consumer": False,
 }
 

--- a/test/test_basebackup_operation.py
+++ b/test/test_basebackup_operation.py
@@ -286,12 +286,13 @@ def test_process_binlog_info(mysql_master: MySQLConfig) -> None:
     }
 
 
-def _make_backup_op(*, estimate_memory: bool = False) -> BasebackupOperation:
+def _make_backup_op(*, estimate_memory: bool = False, lock_ddl: str = myhoard_util.LOCK_DDL_ON) -> BasebackupOperation:
     # /dev/null is read for the mysql config at construction time; no live server or subprocess is needed.
     op = BasebackupOperation(
         encryption_algorithm="AES256",
         encryption_key=b"0" * 24,
         estimate_memory=estimate_memory,
+        lock_ddl=lock_ddl,
         mysql_client_params={"host": "127.0.0.1"},
         mysql_config_file_name="/dev/null",
         mysql_data_directory="/dev/null",
@@ -319,3 +320,29 @@ def test_build_backup_command_line_estimate_memory_enabled() -> None:
         mysql_config_file_name="/etc/mysql/my.cnf", encryption_key_file_name="/tmp/key.bin"
     )
     assert "--estimate-memory=ON" in command_line
+
+
+@pytest.mark.parametrize(
+    ("lock_ddl", "xtrabackup_version", "expected_option"),
+    [
+        # ON is xtrabackup's own default so the option is left out and the command line stays what
+        # MyHoard has always produced
+        (myhoard_util.LOCK_DDL_ON, (8, 4, 8, 1), None),
+        (myhoard_util.LOCK_DDL_REDUCED, (8, 4, 8, 1), "--lock-ddl=REDUCED"),
+        # 8.0 has no REDUCED enum value and refuses to start with it, so it must not be requested
+        (myhoard_util.LOCK_DDL_REDUCED, (8, 0, 35, 30), None),
+        # a value we don't know must not be passed through to xtrabackup either
+        ("BOGUS", (8, 4, 8, 1), None),
+    ],
+)
+def test_build_backup_command_line_lock_ddl(
+    lock_ddl: str, xtrabackup_version: myhoard_util.BinVersion, expected_option: str | None
+) -> None:
+    op = _make_backup_op(lock_ddl=lock_ddl)
+    with patch("myhoard.basebackup_operation.get_xtrabackup_version", return_value=xtrabackup_version):
+        command_line = op._build_backup_command_line(  # pylint: disable=protected-access
+            mysql_config_file_name="/etc/mysql/my.cnf", encryption_key_file_name="/tmp/key.bin"
+        )
+
+    lock_ddl_options = [option for option in command_line if option.startswith("--lock-ddl")]
+    assert lock_ddl_options == ([expected_option] if expected_option else [])

--- a/test/test_basebackup_restore_operation.py
+++ b/test/test_basebackup_restore_operation.py
@@ -3,6 +3,7 @@ from . import build_statsd_client, wait_for_port
 from .helpers.version import xtrabackup_version_to_string
 from myhoard.basebackup_operation import BasebackupOperation
 from myhoard.basebackup_restore_operation import BasebackupRestoreOperation
+from packaging.version import Version
 from unittest.mock import patch
 
 import myhoard.util as myhoard_util
@@ -11,6 +12,8 @@ import pytest
 import shutil
 import subprocess
 import tempfile
+import threading
+import time
 
 pytestmark = [pytest.mark.unittest, pytest.mark.all]
 
@@ -252,6 +255,174 @@ def test_basic_restore(mysql_master, mysql_empty):
         cursor.execute(mysql_master.show_binary_logs_status_cmd)
         new_master_status = cursor.fetchone()
         assert old_master_status["Executed_Gtid_Set"] == new_master_status["Executed_Gtid_Set"]
+
+
+@pytest.mark.parametrize("lock_ddl", [myhoard_util.LOCK_DDL_ON, myhoard_util.LOCK_DDL_REDUCED])
+def test_backup_and_restore_with_lock_ddl(mysql_master, mysql_empty, lock_ddl: str) -> None:
+    """Takes a real backup with the given lock_ddl setting while DDL runs on the server, and restores it.
+
+    DDL during the copy is the only thing `--lock-ddl=REDUCED` changes: ON takes the DDL lock before the
+    copy starts and holds it until the copy ends, so DDL simply waits, while REDUCED lets the DDL through
+    and defers reconciling the affected tables to `--prepare`. Running the whole backup and restore flow
+    for both values is what proves that deferred reconciliation actually produces a restorable server.
+    """
+    if lock_ddl == myhoard_util.LOCK_DDL_REDUCED:
+        xtrabackup_version = myhoard_util.get_xtrabackup_version()
+        if xtrabackup_version < (8, 4):
+            pytest.skip(f"--lock-ddl=REDUCED needs Percona XtraBackup 8.4+, running {xtrabackup_version}")
+        if mysql_master.version < Version("8.4.0"):
+            pytest.skip(f"--lock-ddl=REDUCED needs MySQL 8.4+, running {mysql_master.version}")
+
+    baseline_table_count = 5
+    baseline_row_count = 15
+    ddl_row_count = 10
+
+    with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
+        cursor.execute("CREATE DATABASE db_test")
+        for table_index in range(baseline_table_count):
+            cursor.execute(f"CREATE TABLE db_test.baseline{table_index} (id integer primary key)")
+            values = ", ".join(f"({value})" for value in range(baseline_row_count))
+            cursor.execute(f"INSERT INTO db_test.baseline{table_index} (id) VALUES {values}")
+        # Kept separate from the baseline tables so that ALTERing it below doesn't make the assertions on
+        # those ambiguous.
+        cursor.execute("CREATE TABLE db_test.alter_target (id integer primary key, payload varchar(64))")
+        values = ", ".join(f"({value}, 'payload{value}')" for value in range(baseline_row_count))
+        cursor.execute(f"INSERT INTO db_test.alter_target (id, payload) VALUES {values}")
+        cursor.execute("COMMIT")
+        cursor.execute("FLUSH LOGS")
+
+    stop_ddl = threading.Event()
+    created_tables: list[str] = []
+    ddl_errors: list[Exception] = []
+
+    def run_ddl() -> None:
+        # With lock_ddl=ON the very first statement blocks for as long as the copy takes, so this connection
+        # needs a read timeout far above the default 4s.
+        connect_options = dict(mysql_master.connect_options, timeout=300)
+        try:
+            with myhoard_util.mysql_cursor(**connect_options) as ddl_cursor:
+                # ADD INDEX rewrites an existing data file, which is the case REDUCED has to recopy
+                ddl_cursor.execute("ALTER TABLE db_test.alter_target ADD INDEX payload_index (payload)")
+                table_index = 0
+                while not stop_ddl.is_set():
+                    # CREATE TABLE auto-commits and the rows land in a separate transaction, so a
+                    # consistent snapshot can hold the table with all of its rows or with none of them
+                    table_name = f"ddl{table_index}"
+                    ddl_cursor.execute(f"CREATE TABLE db_test.{table_name} (id integer primary key)")
+                    values = ", ".join(f"({value})" for value in range(ddl_row_count))
+                    ddl_cursor.execute(f"INSERT INTO db_test.{table_name} (id) VALUES {values}")
+                    ddl_cursor.execute("COMMIT")
+                    created_tables.append(table_name)
+                    table_index += 1
+                    time.sleep(0.05)
+        except Exception as ex:  # pylint: disable=broad-except
+            ddl_errors.append(ex)
+
+    encryption_key = os.urandom(24)
+
+    with tempfile.NamedTemporaryFile() as backup_file:
+
+        def output_stream_handler(stream):
+            shutil.copyfileobj(stream, backup_file)
+
+        backup_op = BasebackupOperation(
+            encryption_algorithm="AES256",
+            encryption_key=encryption_key,
+            lock_ddl=lock_ddl,
+            mysql_client_params=mysql_master.connect_options,
+            mysql_config_file_name=mysql_master.config_name,
+            mysql_data_directory=mysql_master.config_options.datadir,
+            stats=build_statsd_client(),
+            stream_handler=output_stream_handler,
+            temp_dir=mysql_master.base_dir,
+        )
+
+        ddl_thread = threading.Thread(target=run_ddl, name="ddl-during-backup")
+        ddl_thread.start()
+        try:
+            backup_op.create_backup()
+        finally:
+            stop_ddl.set()
+            ddl_thread.join(timeout=300)
+
+        assert not ddl_errors, f"DDL failed while backing up: {ddl_errors}"
+        assert not ddl_thread.is_alive()
+        if lock_ddl == myhoard_util.LOCK_DDL_REDUCED:
+            # The point of REDUCED: DDL is not blocked for the duration of the copy
+            assert created_tables, "no DDL got through during the backup, REDUCED did not reduce the lock"
+
+        with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
+            cursor.execute(mysql_master.show_binary_logs_status_cmd)
+            source_status = cursor.fetchone()
+            assert source_status
+            source_gtid_executed = source_status["Executed_Gtid_Set"]
+
+        backup_file.seek(0)
+
+        def input_stream_handler(stream):
+            shutil.copyfileobj(backup_file, stream)
+            stream.close()
+
+        with tempfile.TemporaryDirectory(dir=mysql_empty.base_dir, prefix="myhoard_target_") as temp_target_dir:
+            restore_op = BasebackupRestoreOperation(
+                encryption_algorithm="AES256",
+                encryption_key=encryption_key,
+                free_memory_percentage=80,
+                mysql_config_file_name=mysql_empty.config_name,
+                mysql_data_directory=mysql_empty.config_options.datadir,
+                stats=build_statsd_client(),
+                stream_handler=input_stream_handler,
+                target_dir=temp_target_dir,
+                temp_dir=mysql_empty.base_dir,
+                backup_tool_version=xtrabackup_version_to_string(myhoard_util.get_xtrabackup_version()),
+            )
+            restore_op.prepare_backup(checkpoints_file_content=backup_op.checkpoints_file_content)
+            restore_op.restore_backup()
+
+        assert restore_op.number_of_files >= backup_op.number_of_files
+
+    mysql_empty.proc = subprocess.Popen(mysql_empty.startup_command)  # pylint: disable=consider-using-with
+    wait_for_port(mysql_empty.port)
+
+    with myhoard_util.mysql_cursor(
+        password=mysql_master.password,
+        port=mysql_empty.port,
+        user=mysql_master.user,
+    ) as cursor:
+        # Everything that was committed before the backup started must be there in full
+        for table_index in range(baseline_table_count):
+            cursor.execute(f"SELECT id FROM db_test.baseline{table_index}")
+            rows = cursor.fetchall()
+            assert sorted(row["id"] for row in rows) == list(range(baseline_row_count))
+
+        cursor.execute("SELECT id, payload FROM db_test.alter_target")
+        rows = cursor.fetchall()
+        assert sorted((row["id"], row["payload"]) for row in rows) == [
+            (value, f"payload{value}") for value in range(baseline_row_count)
+        ]
+
+        # Tables created while the backup ran may or may not have made the snapshot, but the ones that did
+        # must be readable and hold either all of their rows or none, never a partial transaction
+        cursor.execute("SELECT table_name AS name FROM information_schema.tables WHERE table_schema = 'db_test'")
+        restored_ddl_tables = {row["name"] for row in cursor.fetchall() if row["name"].startswith("ddl")}
+        assert restored_ddl_tables <= set(created_tables)
+        for table_name in sorted(restored_ddl_tables):
+            cursor.execute(f"SELECT id FROM db_test.{table_name}")
+            rows = cursor.fetchall()
+            ids = sorted(row["id"] for row in rows)
+            assert ids in ([], list(range(ddl_row_count))), f"{table_name} restored with a partial transaction: {ids}"
+
+        # The restored server must sit at a point that really existed in the source's history
+        cursor.execute(mysql_master.show_binary_logs_status_cmd)
+        restored_status = cursor.fetchone()
+        assert restored_status
+        cursor.execute(
+            "SELECT GTID_SUBSET(%s, %s) AS is_subset",
+            (restored_status["Executed_Gtid_Set"], source_gtid_executed),
+        )
+        gtid_subset = cursor.fetchone()
+        assert gtid_subset
+        assert gtid_subset["is_subset"] == 1
 
 
 def test_incremental_backup_restore(mysql_master, mysql_empty) -> None:


### PR DESCRIPTION
# About this change: What it does, why it matters

Pass `--lock-ddl=REDUCED` to `xtrabackup --backup` when the new `lock_ddl`
xtrabackup setting asks for it. With the default ON the DDL lock is taken
before the data files are copied and held until the copy ends, so it lasts
as long as the backup and grows with the dataset. REDUCED copies InnoDB
data unlocked, tracks DDL through the redo log and takes a short lock at
the end only to reconcile the tables that DDL touched, which keeps the lock
window roughly flat as data grows. Measured on 27GB, the lock dropped from
~120s with ON to ~2.3s with REDUCED.

The setting defaults to ON in DEFAULT_XTRABACKUP_SETTINGS, and ON leaves
the option off the command line entirely, so the command line is unchanged
unless callers opt in.

REDUCED only exists in Percona XtraBackup 8.4 and newer, so it is gated on
the version of the binary that is about to run, which also covers the
MySQL 8.4+ requirement of the feature. An older xtrabackup, or a value we
don't recognise, logs a warning and falls back to ON instead of failing
every backup attempt. OFF is deliberately not accepted because it leaves
DDL executed during the copy unprotected.

REDUCED works for both full and incremental backups but cannot be combined
with xtrabackup's page tracking, which MyHoard does not use.