### PR TITLE
Disable scheduled backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ been created otherwise. This setting ensures that environments with low rate of
 changes so that new binary logs are not created because the size limit is
 exceeded also get all data backed up frequently enough.
 
+**scheduled_backups_enabled**
+
+Boolean setting, defaults to `true`. When set to `false`, MyHoard will not
+automatically schedule new backups based on `backup_interval_minutes`,
+`backup_hour` and `backup_minute`. Backups can still be triggered manually via
+`POST /backup`. This is useful when backup timing should be fully controlled
+by an external scheduler rather than MyHoard itself. Note that this only
+affects new base backup scheduling; binary log uploads and existing backup
+streams continue as usual.
+
 **upload_site**
 
 Name of the backup site to which new backups should be created to. See

--- a/myhoard.json
+++ b/myhoard.json
@@ -7,6 +7,7 @@
         "backup_interval_minutes": 1440,
         "backup_minute": 0,
         "forced_binlog_rotation_interval": 300,
+        "scheduled_backups_enabled": true,
         "upload_site": "default",
         "incremental": {
             "enabled": false,

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1509,6 +1509,10 @@ class Controller(threading.Thread):
         return None
 
     def _mark_periodic_backup_requested_if_interval_exceeded(self):
+        if not self.backup_settings.get("scheduled_backups_enabled", True):
+            self.log.debug("Skipping backup interval check, scheduled backups are disabled")
+            return
+
         paused_backups_until: str | None = self.state["paused_backups_until"]
         if paused_backups_until is not None and datetime.datetime.fromisoformat(
             paused_backups_until

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -386,6 +386,7 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
             "backup_interval_minutes": 1440,
             "backup_minute": 0,
             "forced_binlog_rotation_interval": 300,
+            "scheduled_backups_enabled": True,
             "upload_site": "default",
             "incremental": {"enabled": False, "full_backup_week_schedule": "sun,wed"},
         },

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1842,6 +1842,46 @@ def test_periodic_backups_are_paused(time_machine, master_controller) -> None:
     while_asserts(lambda: streaming_binlogs(m_controller, 2), timeout=10)
 
 
+def test_scheduled_backups_can_be_disabled(time_machine, master_controller) -> None:
+    # pylint: disable=protected-access
+    time_machine.move_to("2023-01-02T18:00:00")
+
+    # By default backup_hour = 3, backup_interval_minutes = 1440
+    m_controller, master = master_controller
+
+    m_controller.switch_to_active_mode()
+    m_controller.start()
+
+    def streaming_binlogs(controller: Controller, expected_completed_backups: int):
+        assert controller.backup_streams
+        assert controller.backup_streams[0].active_phase == BackupStream.ActivePhase.binlog
+
+        complete_backups = [backup for backup in controller.state["backups"] if backup["completed_at"]]
+        assert len(complete_backups) == expected_completed_backups
+
+    def flush_binlogs():
+        with mysql_cursor(**master.connect_options) as cursor:
+            cursor.execute("FLUSH BINARY LOGS")
+
+    flush_binlogs()
+
+    while_asserts(lambda: streaming_binlogs(m_controller, 1), timeout=10)
+
+    # Disable scheduled backups
+    m_controller.backup_settings["scheduled_backups_enabled"] = False
+
+    flush_binlogs()
+
+    # Time passes well beyond the normal daily backup schedule but no new backup should be scheduled
+    time_machine.move_to("2023-01-11T03:00:00+00:00")
+    time.sleep(1)
+    streaming_binlogs(m_controller, 1)
+
+    # Manual backup requests still work while scheduled backups are disabled
+    m_controller.mark_backup_requested(backup_reason=BackupStream.BackupReason.requested)
+    while_asserts(lambda: streaming_binlogs(m_controller, 2), timeout=10)
+
+
 def test_changed_backup_hour_is_applied(time_machine, master_controller) -> None:
     # pylint: disable=protected-access
     time_machine.move_to("2023-01-02T03:30:00")

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1843,7 +1843,6 @@ def test_periodic_backups_are_paused(time_machine, master_controller) -> None:
 
 
 def test_scheduled_backups_can_be_disabled(time_machine, master_controller) -> None:
-    # pylint: disable=protected-access
     time_machine.move_to("2023-01-02T18:00:00")
 
     # By default backup_hour = 3, backup_interval_minutes = 1440


### PR DESCRIPTION
Enable (default) or disable automatic scheduled backups.

This is useful when backup timing should be fully controlled
by an external scheduler rather than MyHoard itself. Note that this only
affects new base backup scheduling; binary log uploads and existing backup
streams continue as usual.

### Unit tests

```
$ hatch run python -m pytest -q test/test_controller.py                                        

.....s............................................................................                                                                                                     [100%]
====================================================================================== warnings summary ======================================================================================
test/test_controller.py: 520 warnings
  /usr/lib/python3.12/contextlib.py:137: DeprecationWarning: 'db' is deprecated, use 'database'
    return next(self.gen)
...

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
81 passed, 1 skipped, 522 warnings in 503.20s (0:08:23)
```
